### PR TITLE
Add Wechaty docs site as we just adopted

### DIFF
--- a/adoption.rst
+++ b/adoption.rst
@@ -38,6 +38,7 @@ bodies of documentation. In some cases the adoption remains partial or is still 
 * `PIconnect <https://piconnect.readthedocs.io>`_
 * Tesla Motors (internal)
 * `WebAccess/DMP <https://docs.wadmp.com>`_
+* `Wechaty <https://wechaty.js.org/docs/>`_
 * Zalando (internal)
 
 


### PR DESCRIPTION
Hi Daniele Procida,

Thank you very much for your great talk: [What nobody tells you about documentation, Daniele Procida, 2017, PyCon AU](https://2017.pycon-au.org/schedule/presentation/15/), I updated our Wechaty docs site <https://wechaty.js.org/docs> right after watching your video and reading the documentation system website.

Would love to add us to the adoption list.

Related issue: https://github.com/wechaty/wechaty.js.org/issues/704